### PR TITLE
unit: Mako Server 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,24 +1,58 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1702921762,
-        "narHash": "sha256-O/rP7gulApQAB47u6szEd8Pn8Biw0d84j5iuP2tcxzY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d02ffbbe834b5599fc5f134e644e49397eb07188",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703013332,
+        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,50 +1,33 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  inputs = {
+    nixpkgs = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
 
-  outputs = { self, nixpkgs }: {
-
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
-
-    packages.x86_64-linux.view_note =
-      let
-        pkgs = import nixpkgs { system = "x86_64-linux"; };
-      in
-      pkgs.writeShellScriptBin "view_note" ''
-        ${pkgs.cowsay}/bin/cowsay Note says: help, who, what, where.
-      '';
-
-    packages.x86_64-linux.hello =
-      let
-        pkgs = import nixpkgs { system = "x86_64-linux"; };
-      in
-      pkgs.writeShellScriptBin "hello" ''
+    in rec {
+      defaultApp = flake-utils.lib.mkApp {
+        drv = defaultPackage;
+      };
+      hello = pkgs.writeShellScriptBin "hello" ''
         DATE="$(${pkgs.ddate}/bin/ddate +'the %e of %B%, %Y')"
         ${pkgs.cowsay}/bin/cowsay Today is $DATE. You are standing west of house. There is a note at the wall.
       '';
 
-    # #5 and #7, lets go to the moon and get it running on an embedded device.  
-    nixosConfigurations.container = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules =
-        [ ({ pkgs, ... }: {
-            boot.isContainer = true;
-
-            # Let 'nixos-version --json' know about the Git revision
-            # of this flake.
-            system.configurationRevision = nixpkgs.lib.mkIf (self ? rev) self.rev;
-
-            # Network configuration.
-            networking.useDHCP = false;
-            networking.firewall.allowedTCPPorts = [ 80 ];
-
-            # Enable a web server.
-            services.httpd = {
-              enable = true;
-              adminAddr = "alexeusgr@gmail.com";
-            };
-          })
-        ];
-    };
-
-  };
+      defaultPackage = hello;
+      # devShell = pkgs.mkShell {
+      #   buildInputs = [
+      #     lightgbm-cli
+      #   ];
+      # };
+    }
+  );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,27 @@
         inherit system;
       };
 
+      mako = (with pkgs; stdenv.mkDerivation {
+          pname = "mako";
+          version = "3.3.1";
+          src = fetchgit {
+            url = "https://github.com/nzinfo/MakoServer";
+            rev = "v3.3.1";
+            sha256 = "pBrsey0RpxxvlwSKrOJEBQp7Hd9Yzr5w5OdUuyFpgF8=";
+            fetchSubmodules = true;
+          };
+          nativeBuildInputs = [
+            clang
+            cmake
+          ];
+          buildPhase = "make -j $NIX_BUILD_CORES";
+          installPhase = ''
+            mkdir -p $out/bin
+            mv $TMP/LightGBM/lightgbm $out/bin
+          '';
+        }
+      );
+
     in rec {
       defaultApp = flake-utils.lib.mkApp {
         drv = defaultPackage;
@@ -25,7 +46,7 @@
       defaultPackage = hello;
       # devShell = pkgs.mkShell {
       #   buildInputs = [
-      #     lightgbm-cli
+      #     mako
       #   ];
       # };
     }

--- a/flake.nix
+++ b/flake.nix
@@ -15,12 +15,14 @@
 
       mako = (with pkgs; stdenv.mkDerivation {
           pname = "mako";
-          version = "3.3.1";
+          version = "3158b48586e7dcdfe29777181c5274328d96921a";
           src = fetchgit {
             url = "https://github.com/nzinfo/MakoServer";
-            rev = "v3.3.1";
-            sha256 = "pBrsey0RpxxvlwSKrOJEBQp7Hd9Yzr5w5OdUuyFpgF8=";
-            fetchSubmodules = true;
+            rev = "3158b48586e7dcdfe29777181c5274328d96921a";
+            sha256 = "SuRn81V4rEHTe/FZzoMfylrEiqgRkbIaYrohWMNR+3Q=";
+            fetchSubmodules = false;
+            leaveDotGit = false;
+            deepClone = false;
           };
           nativeBuildInputs = [
             clang

--- a/flake.nix
+++ b/flake.nix
@@ -45,12 +45,12 @@
         ${pkgs.cowsay}/bin/cowsay Today is $DATE. You are standing west of house. There is a note at the wall.
       '';
 
-      defaultPackage = hello;
-      # devShell = pkgs.mkShell {
-      #   buildInputs = [
-      #     mako
-      #   ];
-      # };
+      defaultPackage = mako;
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          mako
+        ];
+      };
     }
   );
 }


### PR DESCRIPTION
[Mako Server](https://github.com/nzinfo/MakoServer) is available on GitHub so [this tutorial](https://dev.to/deciduously/workstation-management-with-nix-flakes-build-a-cmake-c-package-21lp) on building C with nix should work for Mako as well

Accept: any message that suggests that mako can be run, proceed to #5 to validate a user test.

- [x] build C
- [ ] build BAS
- [ ] build Mako